### PR TITLE
Ignore jobs with no methods

### DIFF
--- a/lib/sidekiq/enqueuer.rb
+++ b/lib/sidekiq/enqueuer.rb
@@ -27,7 +27,7 @@ module Sidekiq
           begin
             Worker::Instance.new(job, async: configuration.async)
           rescue => e
-            puts "SJH Sidekiq::Enqueuer - could not load #{job&.inspect} due to #{e&.inspect}"
+            puts "Sidekiq::Enqueuer - could not load #{job&.inspect} due to #{e&.inspect}"
           end
         end
       end

--- a/lib/sidekiq/enqueuer.rb
+++ b/lib/sidekiq/enqueuer.rb
@@ -24,7 +24,11 @@ module Sidekiq
 
       def jobs
         configuration.available_jobs.map do |job|
-          Worker::Instance.new(job, async: configuration.async)
+          begin
+            Worker::Instance.new(job, async: configuration.async)
+          rescue => e
+            puts "SJH Sidekiq::Enqueuer - could not load #{job&.inspect} due to #{e&.inspect}"
+          end
         end
       end
     end

--- a/lib/sidekiq/enqueuer/utils.rb
+++ b/lib/sidekiq/enqueuer/utils.rb
@@ -12,7 +12,7 @@ module Sidekiq
       end
 
       def sidekiq_job?(job_class)
-        job_class.included_modules.include?(::Sidekiq::Worker)
+        job_class.included_modules.include?(::Sidekiq::Worker) && job_class.instance_methods.any? { |method| method.start_with?("perform") }
       end
     end
   end

--- a/lib/sidekiq/enqueuer/worker/instance.rb
+++ b/lib/sidekiq/enqueuer/worker/instance.rb
@@ -7,8 +7,8 @@ module Sidekiq
         attr_reader :job, :instance_method, :params, :async
 
         def initialize(job, async:)
-          puts "SJH Sidekiq::Enqueuer::Worker::Instance.initialize - job #{job.inspect}"
           @job = job
+          puts "SJH Sidekiq::Enqueuer::Worker::Instance.initialize - job #{@job.inspect}"
           @async = async
           @instance_method = deduce_instance_method
           @params = deduce_params
@@ -35,6 +35,7 @@ module Sidekiq
         # TODO: what if two of this methods exist? which one to pick to figure out params?
         def deduce_instance_method
           [:perform, :perform_in, :perform_async, :perform_at].each do |evaluating_method|
+            puts "SJH Sidekiq::Enqueuer::Worker::Instance.initialize - job #{@job.inspect} - considering #{evaluating_method}"
             return evaluating_method if job.instance_methods.include?(evaluating_method)
           end
           nil
@@ -47,7 +48,11 @@ module Sidekiq
         end
 
         def worker_params
-          job.instance_method(instance_method).parameters
+          begin
+            job.instance_method(instance_method).parameters
+          rescue => e
+            puts "SJH Sidekiq::Enqueuer::Worker::Instance.initialize - job #{job.inspect} - issue with parameters in #{instance_method}, exception: #{e&.inspect}"
+          end
         end
       end
     end

--- a/lib/sidekiq/enqueuer/worker/instance.rb
+++ b/lib/sidekiq/enqueuer/worker/instance.rb
@@ -8,7 +8,7 @@ module Sidekiq
 
         def initialize(job, async:)
           @job = job
-          puts "SJH Sidekiq::Enqueuer::Worker::Instance.initialize - job #{@job.inspect}"
+          # puts "Sidekiq::Enqueuer::Worker::Instance.initialize - job #{@job.inspect}"
           @async = async
           @instance_method = deduce_instance_method
           @params = deduce_params
@@ -35,7 +35,7 @@ module Sidekiq
         # TODO: what if two of this methods exist? which one to pick to figure out params?
         def deduce_instance_method
           [:perform, :perform_in, :perform_async, :perform_at].each do |evaluating_method|
-            puts "SJH Sidekiq::Enqueuer::Worker::Instance.initialize - job #{@job.inspect} - considering #{evaluating_method}"
+            # puts "Sidekiq::Enqueuer::Worker::Instance.initialize - job #{@job.inspect} - considering #{evaluating_method}"
             return evaluating_method if job.instance_methods.include?(evaluating_method)
           end
           nil
@@ -51,7 +51,7 @@ module Sidekiq
           begin
             job.instance_method(instance_method).parameters
           rescue => e
-            puts "SJH Sidekiq::Enqueuer::Worker::Instance.initialize - job #{job.inspect} - issue with parameters in #{instance_method}, exception: #{e&.inspect}"
+            puts "Sidekiq::Enqueuer::Worker::Instance.initialize - job #{job.inspect} - issue with parameters in #{instance_method}, exception: #{e&.inspect}"
           end
         end
       end

--- a/lib/sidekiq/enqueuer/worker/instance.rb
+++ b/lib/sidekiq/enqueuer/worker/instance.rb
@@ -7,6 +7,7 @@ module Sidekiq
         attr_reader :job, :instance_method, :params, :async
 
         def initialize(job, async:)
+          put "SJH Sidekiq::Enqueuer::Worker::Instance.initialize - job #{job.inspect}"
           @job = job
           @async = async
           @instance_method = deduce_instance_method

--- a/lib/sidekiq/enqueuer/worker/instance.rb
+++ b/lib/sidekiq/enqueuer/worker/instance.rb
@@ -7,7 +7,7 @@ module Sidekiq
         attr_reader :job, :instance_method, :params, :async
 
         def initialize(job, async:)
-          put "SJH Sidekiq::Enqueuer::Worker::Instance.initialize - job #{job.inspect}"
+          puts "SJH Sidekiq::Enqueuer::Worker::Instance.initialize - job #{job.inspect}"
           @job = job
           @async = async
           @instance_method = deduce_instance_method


### PR DESCRIPTION
We use a module to define certain common attributes and methods across our jobs, however as it includes `Sidekiq::Worker` sidekiq-enquerer picks this up and tries to find the `perform*` instance methods on it. As there isn't any, it fails with the error 

`nil is not a symbol nor a string`

This change skips those jobs that don't have an `perform*` instance methods on them.

